### PR TITLE
fix tests by adding the CartStateProvider

### DIFF
--- a/sick-fits/frontend/__tests__/Product.test.js
+++ b/sick-fits/frontend/__tests__/Product.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { MockedProvider } from '@apollo/react-testing';
+import { CartStateProvider } from '../lib/cartState';
 
 import Product from '../components/Product';
 import { fakeItem } from '../lib/testUtils';
@@ -10,9 +11,11 @@ const product = fakeItem();
 describe('<Product/>', () => {
   it('renders out the price tag and title', () => {
     const { container, debug } = render(
-      <MockedProvider>
-        <Product product={product} />
-      </MockedProvider>
+      <CartStateProvider>
+        <MockedProvider>
+          <Product product={product} />
+        </MockedProvider>
+      </CartStateProvider>
     );
     debug();
   });

--- a/sick-fits/frontend/babel.config.json
+++ b/sick-fits/frontend/babel.config.json
@@ -1,3 +1,0 @@
-{
-"presets": ["@babel/preset-env", "@babel/preset-react"]
-}

--- a/sick-fits/frontend/jest.setup.js
+++ b/sick-fits/frontend/jest.setup.js
@@ -1,7 +1,3 @@
 import '@testing-library/jest-dom';
 
-import React from 'react';
-
 window.alert = console.log;
-
-global.React = React; // this also works for other globally available libraries


### PR DESCRIPTION
You were using the `useCart` hook but never added the CartStateProvider to the test, it cannot destructure the cart if it isn't provided in the test.

You don't need a babel file, it's already configured in the `package.json` file. You also don't need to import React into the testing environment, that is already being done by the testing environment.